### PR TITLE
Add changelog for Raya Haji Update (2026)

### DIFF
--- a/app/[locale]/changelog/page.mdx
+++ b/app/[locale]/changelog/page.mdx
@@ -1,11 +1,14 @@
 import MdxLayout from '@/components/mdx-layout'
 import ChangelogHeader from '@/components/changelog-header'
 
-<ChangelogHeader version="2.13.11" date="16 May 2026" githubSlug="2.13.11+170" hijriDate="19 Syawal 1447"/>
+<ChangelogHeader version="2.14.0" date="18 May 2026" githubSlug="2.14.0+173" hijriDate="1 Zulhijjah 1447"/>
 
-- Refreshed the Share as Image feature with improved visuals and layout styling.
-
+- Refreshed the **Share as Image** feature with improved visuals and layout styling.
   ![Screenshots](https://bucket.waktusolat.app/site-images/Changelog%20share%20image.png)
+- Added padding to the bottom of **monthly timetable page** to prevent the last row from being obscured by the download button.
+- Upgrade dependencies
+- [DEV]
+  - Added ability to turn the developer mode off.
 
 <ChangelogHeader version="2.13.11" date="8 April 2026" githubSlug="2.13.11+170" hijriDate="19 Syawal 1447"/>
 

--- a/app/[locale]/changelog/page.mdx
+++ b/app/[locale]/changelog/page.mdx
@@ -1,6 +1,12 @@
 import MdxLayout from '@/components/mdx-layout'
 import ChangelogHeader from '@/components/changelog-header'
 
+<ChangelogHeader version="2.13.11" date="16 May 2026" githubSlug="2.13.11+170" hijriDate="19 Syawal 1447"/>
+
+- Refreshed the Share as Image feature with improved visuals and layout styling.
+
+  ![Screenshots](https://bucket.waktusolat.app/site-images/Changelog%20share%20image.png)
+
 <ChangelogHeader version="2.13.11" date="8 April 2026" githubSlug="2.13.11+170" hijriDate="19 Syawal 1447"/>
 
 - Fix bug that causes the app to stuck at splash screen on launches. The issue was caused by the app couldn't find the provided timezone data. Issue [#270](https://github.com/mptwaktusolat/app_waktu_solat_malaysia/issues/270)

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "eslint-config-next": "14.2.35",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19"
-  }
+  },
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
 }


### PR DESCRIPTION
This PR adds the changelog entries for the release https://github.com/mptwaktusolat/app_waktu_solat_malaysia/releases/tag/2.14.0%2B173.

Also, upgraded to pnpm@11.1.2